### PR TITLE
PTI updates to make volume header 50 & beat slice work during export to pti

### DIFF
--- a/pti.rst
+++ b/pti.rst
@@ -40,27 +40,27 @@ The header of a ``.pti`` file is 392 bytes long and has the following format:
 |       4 |                   | * 1:                                        |
 |         |                   |                                             |
 +---------+-------------------+---------------------------------------------+
-|       5 |                   | * 2:                                        |
-|         |                   | * 4:                                        |
-|         |                   | * 5:                                        |
+|       5 | Format indicator  | * 9: Required for proper export             |
+|         | **CRITICAL**      | * Other values may cause issues             |
 |         |                   |                                             |
 +---------+-------------------+---------------------------------------------+
-|       6 |                   | * 0:                                        |
-|         |                   | * 1:                                        |
-|         |                   | * 2:                                        |
+|       6 | Header flag       | * 1: Required for proper export             |
+|         | **CRITICAL**      | * 0: May cause compatibility issues         |
 |         |                   |                                             |
 +---------+-------------------+---------------------------------------------+
-|       7 |                   | * 1:                                        |
+|       7 |                   | * 0: padding                                |
 |         |                   |                                             |
 +---------+-------------------+---------------------------------------------+
-|    8-11 |                   | * 6:                                        |
-|         |                   | * 9:                                        |
+|    8-11 | Unknown block     | * 9,9,9,9: Required for proper export       |
+|         | **CRITICAL**      | * All zeros will cause issues               |
 |         |                   |                                             |
 +---------+-------------------+---------------------------------------------+
-|      12 |                   | * 116:                                      |
+|      12 | Unknown           | * 116: Required for proper export           |
+|         | **CRITICAL**      | * 0: Will cause issues                      |
 |         |                   |                                             |
 +---------+-------------------+---------------------------------------------+
-|      13 |                   | * 1:                                        |
+|      13 | Unknown           | * 1: Required for proper export             |
+|         | **CRITICAL**      | * 0: Will cause issues                      |
 |         |                   |                                             |
 +---------+-------------------+---------------------------------------------+
 |      14 |                   | * 0:                                        |
@@ -72,7 +72,8 @@ The header of a ``.pti`` file is 392 bytes long and has the following format:
 |         |                   | * 102:                                      |
 |         |                   |                                             |
 +---------+-------------------+---------------------------------------------+
-|      16 |                   | * 1:                                        |
+|      16 | Unknown           | * 1: Required for proper export             |
+|         | **CRITICAL**      | * 0: Will cause issues                      |
 |         |                   |                                             |
 +---------+-------------------+---------------------------------------------+
 |   17-19 |                   | * 0:                                        |
@@ -92,8 +93,9 @@ The header of a ``.pti`` file is 392 bytes long and has the following format:
 |   52-55 |                   | * 0:                                        |
 |         |                   |                                             |
 +---------+-------------------+---------------------------------------------+
-|   56-59 |                   | * ?: Unknown                                |
-|         |                   |                                             |
+|   56-59 | Unknown block     | * Non-zero: Required for proper export      |
+|         | **CRITICAL**      | * All zeros will cause issues               |
+|         |                   | * Recommend: 1,0,0,0                        |
 +---------+-------------------+---------------------------------------------+
 |   60-63 | Sample length     | * long: 0-4294967295                        |
 |         |                   | * default: 0                                |
@@ -102,14 +104,15 @@ The header of a ``.pti`` file is 392 bytes long and has the following format:
 +---------+-------------------+---------------------------------------------+
 |   64-65 | Wavetable window  | * short: 32, 64, 128, 256, 1024, 2048       |
 |         | size              | * default: 2048                             |
-|         |                   |                                             |
+|         |                   | * **CRITICAL**: Must be set properly        |
+|         |                   | * Offset 65: Set to 8 for 2048 window       |
 +---------+-------------------+---------------------------------------------+
 |   66-67 |                   | * 0:                                        |
 |         |                   |                                             |
 +---------+-------------------+---------------------------------------------+
 |   68-69 | Wavetable total   | * short: 0-65535                            |
-|         | positions         |                                             |
-|         |                   |                                             |
+|         | positions         | * **CRITICAL**: Must be set for export      |
+|         |                   | * Recommend: 94 for working files           |
 +---------+-------------------+---------------------------------------------+
 |   70-75 |                   | * 0:                                        |
 |         |                   |                                             |
@@ -708,9 +711,9 @@ The header of a ``.pti`` file is 392 bytes long and has the following format:
 |         |                   |                                             |
 +---------+-------------------+---------------------------------------------+
 |     272 | Volume            | * 0: -inf dB                                |
-|         |                   | * 1-100: -/+24 dB                           |
-|         |                   | * default: 50 (0 dB)                        |
-|         |                   |                                             |
+|         |                   | * **CORRECTED**: 50 = 0.0 dB (unity)        |
+|         |                   | * **NOT** -/+24 dB range as previously      |
+|         |                   | * documented - use 50 for 0 dB              |
 +---------+-------------------+---------------------------------------------+
 | 273-275 |                   | * 0:                                        |
 |         |                   |                                             |
@@ -758,7 +761,8 @@ The header of a ``.pti`` file is 392 bytes long and has the following format:
 +---------+-------------------+---------------------------------------------+
 | 378-379 | Granular length   | * Short: 44-44100 (1.0 - 1000.0 ms)         |
 |         |                   | * default: 441 (10 ms)                      |
-|         |                   |                                             |
+|         |                   | * **CRITICAL**: Must be set for export      |
+|         |                   | * Recommend: 441 for working files          |
 +---------+-------------------+---------------------------------------------+
 | 380-381 | Granular position | * short: 0-65535 (start-end)                |
 |         |                   | * default: 0 (start)                        |
@@ -792,7 +796,8 @@ The header of a ``.pti`` file is 392 bytes long and has the following format:
 +---------+-------------------+---------------------------------------------+
 |     386 | Bit depth         | * 4-16: 4-16 bit                            |
 |         |                   | * default: 16                               |
-|         |                   |                                             |
+|         |                   | * **CRITICAL**: Must be set for export      |
+|         |                   | * Required: 16 for working files            |
 +---------+-------------------+---------------------------------------------+
 |     387 |                   | * 0:                                        |
 |         |                   |                                             |
@@ -800,3 +805,44 @@ The header of a ``.pti`` file is 392 bytes long and has the following format:
 | 388-391 |                   | * ?: Unknown                                |
 |         |                   |                                             |
 +---------+-------------------+---------------------------------------------+
+
+**CRITICAL EXPORT REQUIREMENTS**
+=================================
+
+Based on extensive testing, the following fields are **REQUIRED** for proper PTI export
+and compatibility with Polyend Tracker firmware:
+
+**Essential Header Fields (offsets that MUST be set correctly):**
+- Offset 5: Must be 9 (format indicator)
+- Offset 6: Must be 1 (header flag)  
+- Offsets 8-11: Must be 9,9,9,9 (unknown block)
+- Offset 12: Must be 116 (unknown)
+- Offset 13: Must be 1 (unknown)
+- Offset 16: Must be 1 (unknown)
+- Offsets 56-59: Must be non-zero (recommend 1,0,0,0)
+- Offset 65: Must be 8 for wavetable window size (2048)
+- Offset 68: Must be 94 for wavetable positions
+- Offset 272: Must be 50 for 0.0 dB volume (NOT 98 or other values)
+- Offset 376: Slice count (number of slices 0-48)
+- Offset 377: Active slice (which slice is selected)
+- Offsets 378-379: Must be 441 for granular length (10ms)
+- Offset 386: Must be 16 for bit depth
+
+**Playback Modes (offset 76):**
+- 0: 1-Shot
+- 1: Forward loop  
+- 2: Backward loop
+- 3: PingPong loop
+- 4: Slice (regular slicing)
+- 5: Beat slice ← **CONFIRMED WORKING** for RX2/drum loop exports
+- 6: Wavetable
+- 7: Granular
+
+**Export Logic:**
+- IF sample has slices: Use mode 5 (Beat slice), ignore loop settings
+- IF sample has no slices: Use mode 0-3 based on loop mode
+- NEVER mix slice markers with loop data in the same file
+
+**Volume Correction:**
+The previous documentation stating "1-100: -/+24 dB" was INCORRECT.
+Actual behavior: 50 = 0.0 dB (unity gain). Use 50 for normal volume.


### PR DESCRIPTION
here's the discoveries that have been made, comparing "exported based on pti.rst stuff" and "same instrument modified to Beat Slice  and saved out as .pti" files.

hope this helps.